### PR TITLE
Support Ubuntu 14.04

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,9 +1,17 @@
-driver_plugin: vagrant
-driver_config:
-  require_chef_omnibus: true
+---
+driver:
+  name: vagrant
+
+provisioner:
+  name: chef_solo
+  require_chef_omnibus: 11.16.4
 
 platforms:
   - name: ubuntu-12.04
+    run_list:
+      - recipe[apt]
+      - recipe[curl]
+  - name: ubuntu-14.04
     run_list:
       - recipe[apt]
       - recipe[curl]
@@ -12,3 +20,7 @@ suites:
   - name: default
     run_list:
       - recipe[redx::install]
+    attributes:
+      redis:
+        source:
+          url: "http://download.redis.io/releases"

--- a/Berksfile
+++ b/Berksfile
@@ -2,6 +2,11 @@ source "https://api.berkshelf.com"
 
 metadata
 
+cookbook 'apt', '= 2.9.2'
+cookbook 'build-essential', '= 2.2.4'
 cookbook 'curl'
+cookbook 'git', '= 4.3.4'
+cookbook 'logrotate', '= 1.9.2'
+cookbook 'ohai', '= 2.0.4'
+cookbook 'openresty', '= 0.3.5', github: 'priestjim/chef-openresty', tag: '0.3.5'
 cookbook 'redis', :git => 'git@github.com:miah/chef-redis.git', protocol: :git
-cookbook 'openresty', :git => 'git@github.com:priestjim/chef-openresty.git', protocol: :git

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,9 +4,8 @@ maintainer_email 'chad@rstudio.com'
 license 'All rights reserved'
 description 'Installs/Configures redx'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.0.4'
+version '1.0.5'
 
-depends 'redx'
 depends 'git'
 depends 'apt'
 depends 'nginx'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -34,4 +34,9 @@ end
 # install redis server if we're pointing redx to localhost
 include_recipe 'redis::server' if %w( 127.0.0.1 localhost ).include? node['redx']['redis']['host']
 
-package "liblua5.1-socket2"
+case
+when node['lsb']['codename'] == 'precise'
+  package 'liblua5.1-socket2'
+else
+  package 'lua-socket'
+end


### PR DESCRIPTION
- Specify Chef version that is used by RStudio in kitchen
- As a consequence, specify versions of several cookbooks so as not to pull in compat_resource which is a Chef 12 thing
- Set the redis source download because the default googlecode one no longer works

@CBarraford @stevenolen 
